### PR TITLE
Clarifications to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,13 @@
 
 ## Overview
 
-Dart support for EMACS. (not officially supported).
+Dart mode for Emacs.
 
 ## Development status
+
+Not officially supported.
+
+## History
 
 This code is based on the dart-mode.el
 that was previously hosted in the Dart repository


### PR DESCRIPTION
Changed "Dart support for Emacs" to "Dart mode for Emacs" because this isn't adding Emacs support to Dart but the other way around :). Other minor clarifications.
