### PR TITLE
Require cl for emacs 24.4+

### DIFF
--- a/dart-mode.el
+++ b/dart-mode.el
@@ -27,10 +27,10 @@
 ;;; Code:
 
 (require 'cc-mode)
-;; There is a bug in cc-mode, emacs 24.4; for that version require cl.
+;; There is a bug in cc-mode, as of emacs 24.4, for which we require cl.
 ;; http://debbugs.gnu.org/cgi/bugreport.cgi?bug=18845
 (eval-when-compile
-  (if (and (= emacs-major-version 24) (= emacs-minor-version 4))
+  (if (and (= emacs-major-version 24) (>= emacs-minor-version 4))
       (require 'cl)))
 (require 'compile)
 


### PR DESCRIPTION
Previously submitted fix is needed for 24.x for x >= 4, not just x = 4.
